### PR TITLE
Replace pipes ('|') by  '│' (U+2502) in TextHelper+TextWriter

### DIFF
--- a/CK.ActivityMonitor/Client/ActivityMonitorTextHelperClient.cs
+++ b/CK.ActivityMonitor/Client/ActivityMonitorTextHelperClient.cs
@@ -40,7 +40,7 @@ namespace CK.Core
         Stack<bool> _openGroups;
         IActivityMonitorImpl _source;
         static string[] _prefixGroupDepthCache;
-        const string _emptyLinePrefix = "| ";
+        const string _emptyLinePrefix = "\u2502 ";
 
         static ActivityMonitorTextHelperClient()
         {

--- a/CK.ActivityMonitor/Client/ActivityMonitorTextWriterClient.cs
+++ b/CK.ActivityMonitor/Client/ActivityMonitorTextWriterClient.cs
@@ -140,7 +140,7 @@ namespace CK.Core
             var w = _buffer.Clear();
             string levelLabel = g.MaskedGroupLevel.ToString();
             string start = string.Format( "{0}> {1}: ", _prefix, levelLabel );
-            _prefix += "|  ";
+            _prefix += "\u2502  ";
             _prefixLevel = _prefix;
             string prefixLabel = _prefixLevel + new string( ' ', levelLabel.Length + 1 );
 
@@ -223,7 +223,7 @@ namespace CK.Core
 
             string p;
             w.AppendLine( prefix + header );
-            string localPrefix = prefix + " | ";
+            string localPrefix = prefix + " \u2502 ";
             if( displayMessage && ex.Message != null )
             {
                 w.Append( localPrefix + "Message: " );
@@ -266,7 +266,7 @@ namespace CK.Core
                     if( typeLoadEx != null )
                     {
                         w.AppendLine( localPrefix + " ┌──────────────────────────■ [Loader Exceptions] ■──────────────────────────" );
-                        p = localPrefix + " | ";
+                        p = localPrefix + " \u2502 ";
                         foreach( var item in typeLoadEx.LoaderExceptions )
                         {
                             DumpException( w, p, true, item );
@@ -292,7 +292,7 @@ namespace CK.Core
             if( aggrex != null && aggrex.InnerExceptions.Count > 0 )
             {
                 w.AppendLine( localPrefix + " ┌──────────────────────────■ [Aggregated Exceptions] ■──────────────────────────" );
-                p = localPrefix + " | ";
+                p = localPrefix + " \u2502 ";
                 foreach( var item in aggrex.InnerExceptions )
                 {
                     DumpException( w, p, true, item );
@@ -302,7 +302,7 @@ namespace CK.Core
             else if( ex.InnerException != null )
             {
                 w.AppendLine( localPrefix + " ┌──────────────────────────■ [Inner Exception] ■──────────────────────────" );
-                p = localPrefix + " | ";
+                p = localPrefix + " \u2502 ";
                 DumpException( w, p, true, ex.InnerException );
                 w.AppendLine( localPrefix + " └─────────────────────────────────────────────────────────────────────────" );
             }

--- a/Tests/CK.ActivityMonitor.Tests/ActivityMonitorTextWriterClientTests.cs
+++ b/Tests/CK.ActivityMonitor.Tests/ActivityMonitorTextWriterClientTests.cs
@@ -43,20 +43,20 @@ namespace CK.Core.Tests.Monitoring
             string result = b.ToString();
             result.Should().Be(
 @"> Info: IL1
-|       IL2
-|       IL3
-|  > Trace: TL1
-|  |        TL2
-|  |        TL3
-|  |  - Warn: WL1
-|  |          WL2
-|  |          WL3
-|  < c1 - c2
-|  < Multi
-|    Line
-|  < Another
-|    Multi
-|    Line
+│       IL2
+│       IL3
+│  > Trace: TL1
+│  │        TL2
+│  │        TL3
+│  │  - Warn: WL1
+│  │          WL2
+│  │          WL3
+│  < c1 - c2
+│  < Multi
+│    Line
+│  < Another
+│    Multi
+│    Line
 ".NormalizeEOL() );
         }
     }


### PR DESCRIPTION
@Kuinox didn't like pipes, so this replaces them by unicode box lines, which usually occupy the whole line height on a console interface without spaces.

There are many other Unicode box characters (https://en.wikipedia.org/wiki/Box-drawing_character#Unicode), if we're interested in adding some more bling to eg. group open and close lines.