### PR TITLE
Return color code instead of setting console color.

### DIFF
--- a/CK.ActivityMonitor/Client/ColoredActivityMonitorConsoleClient.cs
+++ b/CK.ActivityMonitor/Client/ColoredActivityMonitorConsoleClient.cs
@@ -62,7 +62,9 @@ namespace CK.Core
         /// <param name="logLevel">Current log level.</param>
         protected virtual void SetColor( LogLevel logLevel )
         {
-            DefaultSetColor( _backgroundColor, logLevel );
+            (ConsoleColor background, ConsoleColor foreground) = DefaultColorTheme( _backgroundColor, logLevel );
+            Console.BackgroundColor = background;
+            Console.ForegroundColor = foreground;
         }
 
         /// <summary>
@@ -70,34 +72,24 @@ namespace CK.Core
         /// </summary>
         /// <param name="backgroundColor">Background color to set.</param>
         /// <param name="logLevel">Current log level.</param>
-        public static void DefaultSetColor(ConsoleColor backgroundColor, LogLevel logLevel )
+        public static (ConsoleColor background, ConsoleColor foreground) DefaultColorTheme( ConsoleColor backgroundColor, LogLevel logLevel )
         {
             switch( logLevel )
             {
                 case LogLevel.Fatal:
-                    Console.BackgroundColor = ConsoleColor.DarkRed;
-                    Console.ForegroundColor = ConsoleColor.Yellow;
-                    break;
+                    return (ConsoleColor.DarkRed, ConsoleColor.Yellow);
                 case LogLevel.Error:
-                    Console.BackgroundColor = backgroundColor;
-                    Console.ForegroundColor = ConsoleColor.Red;
-                    break;
+                    return (backgroundColor, ConsoleColor.Red);
                 case LogLevel.Warn:
-                    Console.BackgroundColor = backgroundColor;
-                    Console.ForegroundColor = ConsoleColor.Yellow;
-                    break;
+                    return (backgroundColor, ConsoleColor.Yellow);
                 case LogLevel.Info:
-                    Console.BackgroundColor = backgroundColor;
-                    Console.ForegroundColor = ConsoleColor.Cyan;
-                    break;
+                    return (backgroundColor, ConsoleColor.Cyan);
                 case LogLevel.Trace:
-                    Console.BackgroundColor = backgroundColor;
-                    Console.ForegroundColor = ConsoleColor.Gray;
-                    break;
+                    return (backgroundColor, ConsoleColor.Gray);
                 case LogLevel.Debug:
-                    Console.BackgroundColor = backgroundColor;
-                    Console.ForegroundColor = ConsoleColor.DarkGray;
-                    break;
+                    return (backgroundColor, ConsoleColor.DarkGray);
+                default:
+                    return (ConsoleColor.Red, ConsoleColor.Green);//awful so people may think "something is not right"
             }
         }
 


### PR DESCRIPTION
This API change is required to increase the CK-Monitoring console troughtput (by using a single Console.Write call per log).

Don't merge this until CK-Monitoring changes are done.