### PR TITLE
Added try enter implementation.

### DIFF
--- a/CK.ActivityMonitor/AsyncLock.cs
+++ b/CK.ActivityMonitor/AsyncLock.cs
@@ -222,6 +222,14 @@ namespace CK.Core
         }
 
         /// <summary>
+        /// Take the lock immediatly and return true, or return false.
+        /// </summary>
+        /// <param name="m">The monitor that identifies the activity.</param>
+        /// <returns>true if the lock was taken, false otherwise.</returns>
+        public bool TryEnter( IActivityMonitor m )
+            => Enter( m, 0, default );
+
+        /// <summary>
         /// Leaves the lock that must have been previously entered by the <paramref name="monitor"/>.
         /// </summary>
         /// <param name="monitor">The monitor that currently holds this lock.</param>


### PR DESCRIPTION
While semaphore/asynclock does not have any TryEnter method, it's possible to have this behavior by putting 0ms in `Wait(int millisecond)`.
I believe this behavior is really useful to have on a lock.

I think we should add a few tests to see if this behave correctly.